### PR TITLE
Update camdrv_ss_sr030pc50.c

### DIFF
--- a/drivers/media/video/camdrv_ss_sr030pc50.c
+++ b/drivers/media/video/camdrv_ss_sr030pc50.c
@@ -24,7 +24,7 @@
 #define SR030PC50_REGISTER_SIZE 2
 #define SR030PC50_DELAY_DURATION 0xFF
 
-extern inline struct camdrv_ss_state *to_state(struct v4l2_subdev *sd);
+extern struct camdrv_ss_state *to_state(struct v4l2_subdev *sd);
 
 /*  GPIO numbers  needed for power on sequence.
   * If the same sensor is used for different variants/targets. please define those numbers here


### PR DESCRIPTION
Patch to make compiling with gcc > 4.6 possible.
